### PR TITLE
Update readme to note `Rcpp` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Before installing poolSeq you need to make sure that all the __dependencies__ ar
 * foreach (>= 1.4.2)
 * stringi (>= 0.4-1)
 * matrixStats (>= 0.14.2)
+* Rcpp (>= 1.0.3)
 
 For now you need to install these manually. Once this is done you can proceed by __downloading__ the [latest release] of poolSeq. After the download you can __install__ poolSeq with the following R command:
 


### PR DESCRIPTION
I am installing this package from scratch in a Docker container (`docker run --rm -it ubuntu:18.04`):

```
export DEBIAN_FRONTEND=noninteractive
apt-get update && apt-get install -y --no-install-recommends build-essential libgit2-dev libssl-dev r-base zlib1g-dev
Rscript -e "install.packages(c('remotes', 'data.table', 'foreach', 'stringi', 'matrixStats'))"
Rscript -e 'remotes::install_github("ThomasTaus/poolSeq")'
```


and when I do that, I get:


```
Downloading GitHub repo ThomasTaus/poolSeq@master
Rcpp (NA -> 1.0.3) [CRAN]
Installing 1 packages: Rcpp
Installing package into '/usr/local/lib/R/site-library'
(as 'lib' is unspecified)
trying URL 'https://cloud.r-project.org/src/contrib/Rcpp_1.0.3.tar.gz'
Content type 'application/x-gzip' length 2749025 bytes (2.6 MB)
==================================================
downloaded 2.6 MB
```

While most users probably already have `Rcpp` installed, I figure, might be worth noting in the readme.

Thanks!
