### PR TITLE
added edge case code in case only one biallelic snp exists in dataset…

### DIFF
--- a/R/loadaf.R
+++ b/R/loadaf.R
@@ -295,6 +295,10 @@ read.sync <- function(file, gen, repl, polarization=c("minor", "rising", "refere
   pos <- pos[ikeep]
   ref <- ref[ikeep]
 
+  if (length(ikeep) == 1) {
+    sumCnts <- matrix(sumCnts, nrow=1)
+  }
+
   # determine allele ranks for each position
   alleleRank <- rowRanks(sumCnts+rep(1:4/5,each=nrow(sumCnts)))
   rm(sumCnts)


### PR DESCRIPTION
…; prevents weird error

Hi Thomas,
I encountered a weird bug when testing a script using poolSeq. The script fails due to sumCnts being converted into a 1-dimensional vector rather than a 2-dimensional matrix. I wrote a couple lines of code to fix this edge case and make sure sumCnts is a matrix. Hope this helps!

Best,
Jim